### PR TITLE
Adapt publish data to receive correct object

### DIFF
--- a/src/interactors/PublishData.js
+++ b/src/interactors/PublishData.js
@@ -6,30 +6,6 @@ class PublishData {
     this.cloudConnector = cloudConnector;
   }
 
-  async convertData(schema, data) {
-    const dataToSend = convertToCamelCase(data);
-    dataToSend.sensorId = Number(dataToSend.sensorId);
-
-    const sensorSchema = schema.find(value => value.sensorId === dataToSend.sensorId);
-
-    switch (sensorSchema.valueType) {
-      case 1:
-      case 2:
-        dataToSend.value = Number(dataToSend.value);
-        break;
-      case 3:
-        if (dataToSend.value === 'true') {
-          dataToSend.value = true;
-        } else if (dataToSend.value === 'false') {
-          dataToSend.value = false;
-        }
-        break;
-      default:
-        break;
-    }
-    return dataToSend;
-  }
-
   async execute(id, data) {
     const devices = await this.deviceStore.list();
     const device = devices.find(dev => dev.id === id);
@@ -37,7 +13,7 @@ class PublishData {
       return;
     }
 
-    await this.cloudConnector.publishData(id, [await this.convertData(device.schema, data)]);
+    await this.cloudConnector.publishData(id, data.map(d => convertToCamelCase(d)));
   }
 }
 

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -5,8 +5,8 @@ class DataService {
     this.publishDataInteractor = publishDataInteractor;
   }
 
-  async publish({ id, payload }) {
-    await this.publishDataInteractor.execute(id, payload);
+  async publish({ id, data }) {
+    await this.publishDataInteractor.execute(id, data);
   }
 }
 


### PR DESCRIPTION
This patch remove the function convertData since it will come
already convert by rabbitmq and not from fog.
The fog service sent an onject { id, payload } and in rabbitmq it's
expected to be { id, data }.