### PR TITLE
Add dependency install step to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Configuration is made via a JSON file placed into `knot-fog-connector/config/` f
     "port": 3004,
     "pathname": "/ws",
     "uuid": "78159106-41ca-4022-95e8-2511695ce64c",
-    "token": "d5265dbc4576a88f8654a8fc2c4d46a6d7b85574",
+    "token": "d5265dbc4576a88f8654a8fc2c4d46a6d7b85574"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a KNoT Gateway service that connects the fog to a cloud service.
 ## Quickstart
 
 ```bash
+$ npm install
 $ npm run build
 $ npm start
 ```


### PR DESCRIPTION
Add 'npm install' command to readme to install dependencies.

The quickstart has no step corresponding to the installation of
dependencies. This may confuse developers that are not used to npm and
may think that the '$npm run build' command should already handle
dependencies.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------

**Operating System/Platform:** Arch Linux

**NPM Version:** 6.12.1

**NodeJS Version:** v12.13.0