### PR TITLE
Add CLI to facilitate the development 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -939,9 +939,9 @@
       }
     },
     "amqplib": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.3.tgz",
-      "integrity": "sha512-ZOdUhMxcF+u62rPI+hMtU1NBXSDFQ3eCJJrenamtdQ7YYwh7RZJHOIM1gonVbZ5PyVdYH4xqBPje9OYqk7fnqw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.5.tgz",
+      "integrity": "sha512-sWx1hbfHbyKMw6bXOK2k6+lHL8TESWxjAx5hG8fBtT7wcxoXNIsFxZMnFyBjxt3yL14vn7WqBDe5U6BGOadtLg==",
       "requires": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.5.2",
@@ -1263,9 +1263,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -1466,6 +1466,41 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1698,6 +1733,11 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -1815,8 +1855,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "enabled": {
       "version": "1.0.2",
@@ -2473,7 +2512,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -3103,6 +3141,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -3838,7 +3881,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -4277,7 +4319,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4286,7 +4327,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -4294,8 +4334,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "4.0.1",
@@ -4361,8 +4400,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4817,6 +4855,16 @@
         "uuid": "^3.3.2"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4919,6 +4967,11 @@
       "requires": {
         "semver": "^5.0.3"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.0",
@@ -5782,6 +5835,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
     "widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -5843,6 +5901,41 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5885,10 +5978,73 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        }
+      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@cesarbr/knot-fog-connector-knot-cloud": "^2.0.0",
     "@cesarbr/meshblu": "^1.34.3",
-    "amqplib": "^0.5.3",
+    "amqplib": "^0.5.5",
     "config": "^2.0.1",
     "is-base64": "0.0.6",
     "joi": "^14.3.1",
@@ -27,7 +27,8 @@
     "pre-commit": "^1.2.2",
     "request": "^2.87.0",
     "winston": "^3.0.0",
-    "winston-syslog": "^2.0.0"
+    "winston-syslog": "^2.0.0",
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,0 +1,27 @@
+# AMQP CLI
+
+This CLI aims to ease the development process when sending messages to or from the connector through devices and data API.
+
+### Run
+
+You just need to run `node tools/cli` and see the supported commands on help menu.
+
+### Example
+
+```
+cli <command>
+
+Commands:
+  cli publish-data <device-id> <sensor-id>  Publish <value> as a <sensor-id>
+  <value>
+
+Options:
+  --version   Show version number                                      [boolean]
+  --hostname  AMQP server hostname                        [default: "localhost"]
+  --port      AMQP server port                                   [default: 5672]
+  -h, --help  Show help                                                [boolean]
+```
+
+Publishing data to a device's sensor:
+
+`node tools/cli publish-data b00712c829830501 1`

--- a/tools/cli/cmds/authDevice.js
+++ b/tools/cli/cmds/authDevice.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+
+const authDevice = (args) => {
+  const topic = 'cloud';
+  const key = 'device.cmd.auth';
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    channel.publish(
+      topic,
+      key,
+      Buffer.from(JSON.stringify({ id: args.id, token: args.token })),
+      { persistent: true },
+    );
+
+    setTimeout(() => {
+      connection.close();
+      process.exit(0);
+    }, 500);
+  });
+};
+
+yargs
+  .command({
+    command: 'auth-device <id> <token>',
+    desc: 'Authenticate a device',
+    handler: (args) => {
+      authDevice(args);
+    },
+  });

--- a/tools/cli/cmds/createThing.js
+++ b/tools/cli/cmds/createThing.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+
+const createThing = (args) => {
+  const topic = 'cloud';
+  const key = 'device.register';
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    channel.publish(
+      topic,
+      key,
+      Buffer.from(JSON.stringify({ id: args.id, name: args.name })),
+      { persistent: true },
+    );
+
+    setTimeout(() => {
+      connection.close();
+      process.exit(0);
+    }, 500);
+  });
+};
+
+yargs
+  .command({
+    command: 'create-thing <id> <name>',
+    desc: 'Create a thing',
+    handler: (args) => {
+      createThing(args);
+    },
+  });

--- a/tools/cli/cmds/defaultSchema.js
+++ b/tools/cli/cmds/defaultSchema.js
@@ -1,0 +1,7 @@
+module.exports = {
+  sensorId: 1,
+  valueType: 3,
+  unit: 0,
+  typeId: 65521,
+  name: 'Lamp Status',
+};

--- a/tools/cli/cmds/deleteThing.js
+++ b/tools/cli/cmds/deleteThing.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+
+const deleteThing = (args) => {
+  const topic = 'cloud';
+  const key = 'device.unregister';
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    channel.publish(
+      topic,
+      key,
+      Buffer.from(JSON.stringify({ id: args.id })),
+      { persistent: true },
+    );
+
+    setTimeout(() => {
+      connection.close();
+      process.exit(0);
+    }, 500);
+  });
+};
+
+yargs
+  .command({
+    command: 'delete-thing <id>',
+    desc: 'Unregisters a thing',
+    handler: (args) => {
+      deleteThing(args);
+    },
+  });

--- a/tools/cli/cmds/listDevices.js
+++ b/tools/cli/cmds/listDevices.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+
+const onMessage = (channel, topic, key, callback) => {
+  const { queue } = channel.assertQueue(`${topic}-messages`, { durable: true });
+  channel.bindQueue(queue, topic, key);
+  return channel.consume(queue, callback);
+};
+
+const parseBuffer = buffer => JSON.parse(buffer.toString('utf-8'));
+
+const listDevices = (args) => {
+  const topic = 'fog';
+  const commands = ['device.list'];
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    channel.publish(
+      'cloud',
+      'device.cmd.list',
+      Buffer.from(JSON.stringify({})),
+      { persistent: true },
+    );
+
+    commands.forEach((cmd) => {
+      onMessage(channel, topic, cmd, (message) => {
+        const { content, fields } = message;
+        console.log(`Devices received: ${fields.routingKey}`);
+        console.log(JSON.stringify(parseBuffer(content)));
+        channel.ack(message);
+      });
+    });
+  });
+};
+
+yargs
+  .command({
+    command: 'list-devices',
+    desc: 'List devices from cloud',
+    handler: (args) => {
+      listDevices(args);
+    },
+  });

--- a/tools/cli/cmds/listenCommands.js
+++ b/tools/cli/cmds/listenCommands.js
@@ -12,7 +12,7 @@ const parseBuffer = buffer => JSON.parse(buffer.toString('utf-8'));
 
 const listenCommands = (args) => {
   const topic = 'fog';
-  const commands = ['data.update', 'data.request'];
+  const commands = ['data.update', 'data.request', 'device.auth'];
 
   amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
     commands.forEach((cmd) => {

--- a/tools/cli/cmds/listenCommands.js
+++ b/tools/cli/cmds/listenCommands.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+
+const onMessage = (channel, topic, key, callback) => {
+  const { queue } = channel.assertQueue(`${topic}-messages`, { durable: true });
+  channel.bindQueue(queue, topic, key);
+  return channel.consume(queue, callback);
+};
+
+const parseBuffer = buffer => JSON.parse(buffer.toString('utf-8'));
+
+const listenCommands = (args) => {
+  const topic = 'fog';
+  const commands = ['data.update', 'data.request'];
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    commands.forEach((cmd) => {
+      onMessage(channel, topic, cmd, (message) => {
+        const { content, fields } = message;
+        console.log(`Command received: ${fields.routingKey}`);
+        console.log(JSON.stringify(parseBuffer(content)));
+        channel.ack(message);
+      });
+    });
+  });
+};
+
+yargs
+  .command({
+    command: 'listen-commands',
+    desc: 'Listen to commands from cloud',
+    handler: (args) => {
+      listenCommands(args);
+    },
+  });

--- a/tools/cli/cmds/publishData.js
+++ b/tools/cli/cmds/publishData.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const isBase64 = require('is-base64');
+const amqplib = require('amqplib/callback_api');
+
+const extractData = args => ({
+  id: args['device-id'],
+  data: [{
+    sensorId: args['sensor-id'],
+    value: args.value,
+  }],
+});
+
+const publishData = (args) => {
+  const topic = 'cloud';
+  const key = 'data.publish';
+  amqplib.connect(`amqp://${args.hostname}:${args.port}`, (connectionErr, connection) => {
+    if (connectionErr) {
+      throw connectionErr;
+    }
+
+    connection.createChannel((channelErr, channel) => {
+      if (channelErr) {
+        throw channelErr;
+      }
+
+      channel.assertExchange(topic, 'topic', { durable: true });
+      channel.publish(
+        topic,
+        key,
+        Buffer.from(JSON.stringify(extractData(args))),
+        { persistent: true },
+      );
+
+      setTimeout(() => {
+        connection.close();
+        process.exit(0);
+      }, 500);
+    });
+  });
+};
+
+yargs
+  .command({
+    command: 'publish-data <device-id> <sensor-id> <value>',
+    desc: 'Publish <value> as a <sensor-id>',
+    builder: (_yargs) => {
+      _yargs
+        .positional('device-id', {
+          describe: 'thing\'s ID',
+        })
+        .positional('sensor-id', {
+          describe: 'ID of the sensor that is publishing the data',
+        })
+        .positional('value', {
+          describe: 'Value to be published. Supported types: boolean, number or Base64 strings.',
+          coerce: (value) => {
+            if (isNaN(value)) { // eslint-disable-line no-restricted-globals
+              if (value === 'true' || value === 'false') {
+                return (value === 'true');
+              }
+              if (!isBase64(value)) {
+                throw new Error('Supported types are boolean, number or Base64 strings');
+              }
+              return value;
+            }
+
+            return parseFloat(value);
+          },
+        });
+    },
+    handler: (args) => {
+      publishData(args);
+    },
+  });

--- a/tools/cli/cmds/updateSchema.js
+++ b/tools/cli/cmds/updateSchema.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+const yargs = require('yargs');
+const amqpConnection = require('./../network/connection').connection;
+const schema = require('./defaultSchema');
+
+const updateSchema = (args) => {
+  const topic = 'cloud';
+  const key = 'schema.update';
+
+  amqpConnection(args.hostname, args.port, topic, (connection, channel) => {
+    channel.publish(
+      topic,
+      key,
+      Buffer.from(JSON.stringify({ id: args.id, schema: [schema] })),
+      { persistent: true },
+    );
+
+    setTimeout(() => {
+      connection.close();
+      process.exit(0);
+    }, 500);
+  });
+};
+
+yargs
+  .command({
+    command: 'update-schema <id>',
+    desc: 'Updates thing\'s schema',
+    handler: (args) => {
+      updateSchema(args);
+    },
+  });

--- a/tools/cli/index.js
+++ b/tools/cli/index.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+require('yargs') // eslint-disable-line no-unused-expressions
+  .option('hostname', {
+    describe: 'AMQP server hostname',
+    demandOption: false,
+    default: 'localhost',
+  })
+  .option('port', {
+    describe: 'AMQP server port',
+    demandOption: false,
+    default: 5672,
+  })
+  .commandDir('cmds')
+  .demandCommand()
+  .strict()
+  .alias('h', 'help')
+  .help()
+  .argv;

--- a/tools/cli/network/connection.js
+++ b/tools/cli/network/connection.js
@@ -1,0 +1,16 @@
+const amqplib = require('amqplib/callback_api');
+
+module.exports.connection = (hostname, port, topic, cb) => {
+  amqplib.connect(`amqp://${hostname}:${port}`, (connectionErr, connection) => {
+    if (connectionErr) {
+      throw connectionErr;
+    }
+    connection.createChannel((channelErr, channel) => {
+      if (channelErr) {
+        throw channelErr;
+      }
+      channel.assertExchange(topic, 'topic', { durable: true });
+      cb(connection, channel);
+    });
+  });
+};


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds a command-line interface (CLI) to operate on the connector service. The implemented commands are:

- auth device
- list devices
- listen to commands
- delete thing
- update schema
- create thing
- publish data

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.