### PR TITLE
Change AMQP API to client control retries

### DIFF
--- a/docs/api/amqp.md
+++ b/docs/api/amqp.md
@@ -249,12 +249,23 @@ Message with the device unregistered on the cloud.
 
 JSON in the following format:
   * `id` **String** device ID
+  * `error` **String** a string with detailed error message.
 
-#### Example
+#### Success Response Example
 
 ```json
 {
-  "id":"3aa21010cda96fe9"
+  "id": "3aa21010cda96fe9",
+  "error": null,
+}
+```
+
+#### Error Response Example
+
+```json
+{
+  "id": "3aa21010cda96fe9",
+  "error": "Forbidden",
 }
 ```
 

--- a/docs/api/amqp.md
+++ b/docs/api/amqp.md
@@ -147,17 +147,25 @@ Message with the status of device authentication command.
 
 JSON in the following format:
   * `id` **String** device's ID
-  * `authenticated` **Boolean** authentication result
+  * `error` **String** a string with detailed error message.
 
-#### Example
+#### Success Response Example
 
 ```json
 {
   "id": "3aa21010cda96fe9",
-  "authenticated": true
+  "error": null
 }
 ```
 
+#### Error Response Example
+
+```json
+{
+  "id": "3aa21010cda96fe9",
+  "error": "Unauthorized"
+}
+```
 ### Registered device
 
 Message with the device credentials.

--- a/docs/api/amqp.md
+++ b/docs/api/amqp.md
@@ -165,12 +165,23 @@ JSON in the following format:
     * `id` **String** device ID
     * `token` **String** device token
 
-#### Example
+#### Success Response Example
 
 ```json
 {
-  "id":"3aa21010cda96fe9",
-  "token":"5b67ce6bef21701331152d6297e1bd2b22f91787",
+  "id": "3aa21010cda96fe9",
+  "token": "5b67ce6bef21701331152d6297e1bd2b22f91787",
+  "error": null
+}
+```
+
+#### Error Response Example
+
+```json
+{
+  "id": "3aa21010cda96fe9",
+  "token": "",
+  "error": "Device already exists"
 }
 ```
 

--- a/docs/api/amqp.md
+++ b/docs/api/amqp.md
@@ -99,24 +99,36 @@ Message with the list of devices registered on the cloud.
 JSON in the following format:
   * `devices` **Array (Object)** devices representation
 
-#### Example
+#### Success Response Example
 
 ```json
-[
-  {
-    "id":"3aa21010cda96fe9",
-    "name":"KNoT Dongle",
-    "schema":[
-      {
-        "sensor_id":0,
-        "value_type":3,
-        "unit":0,
-        "type_id":65521,
-        "name":"LED"
-      }
-    ]
-  }
-]
+{
+  "devices": [
+    {
+      "id": "3aa21010cda96fe9",
+      "name": "KNoT Dongle",
+      "schema": [
+        {
+          "sensor_id": 0,
+          "value_type": 3,
+          "unit": 0,
+          "type_id": 65521,
+          "name": "LED"
+        }
+      ]
+    }
+  ],
+  "error": null,
+}
+```
+
+#### Error Response Example
+
+```json
+{
+  "devices": [],
+  "error": "Connection refused"
+}
 ```
 
 ### Device authentication status

--- a/docs/api/amqp.md
+++ b/docs/api/amqp.md
@@ -25,7 +25,8 @@ This document specifies the messages expected by the connector through a publish
 
 ### Update data
 
-Updates a thing's sensor value.
+Updates a thing's sensor value. This message will be on the queue for 10 seconds
+before expires.
 
 #### Exchange
 
@@ -57,7 +58,8 @@ JSON in the following format:
 
 ### Request data
 
-Request a thing's sensor value.
+Request a thing's sensor value. This message will be on the queue for 10 seconds
+before expires.
 
 #### Exchange
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import DeviceStore from 'data/DeviceStore';
 import CloudConnectorFactory from 'network/CloudConnectorFactory';
 import CloudConnectionHandler from 'network/CloudConnectionHandler';
 import AMQPConnectionFactory from 'network/AMQPConnectionFactory';
+import MessagePublisher from 'network/MessagePublisher';
 import MessageHandlerFactory from 'network/MessageHandlerFactory';
 
 // Logger
@@ -28,11 +29,13 @@ async function main() {
     }
 
     const amqpConnection = new AMQPConnectionFactory(settings.rabbitMQ).create();
-    const cloudConnectionHandler = new CloudConnectionHandler(cloud, amqpConnection);
+    const publisher = new MessagePublisher(amqpConnection);
+    const cloudConnectionHandler = new CloudConnectionHandler(cloud, publisher);
     const messageHandler = new MessageHandlerFactory(
       deviceStore,
       cloud,
       amqpConnection,
+      publisher,
     ).create();
 
     await messageHandler.start();

--- a/src/interactors/AuthDevice.js
+++ b/src/interactors/AuthDevice.js
@@ -6,7 +6,7 @@ class AuthenticateDevice {
 
   async execute(id, token) {
     const status = await this.cloud.authDevice(id, token);
-    return this.queue.send('fog', 'device.auth', { id, authenticated: status });
+    return this.queue.sendAuthenticatedDevice({ id, authenticated: status });
   }
 }
 

--- a/src/interactors/AuthDevice.js
+++ b/src/interactors/AuthDevice.js
@@ -1,12 +1,20 @@
 class AuthenticateDevice {
-  constructor(cloud, queue) {
+  constructor(cloud, publisher) {
     this.cloud = cloud;
-    this.queue = queue;
+    this.publisher = publisher;
   }
 
   async execute(id, token) {
-    const status = await this.cloud.authDevice(id, token);
-    return this.queue.sendAuthenticatedDevice({ id, authenticated: status });
+    let error;
+
+    try {
+      const status = await this.cloud.authDevice(id, token);
+      error = status ? null : 'Unauthorized';
+    } catch (err) {
+      error = err.message;
+    }
+
+    return this.publisher.sendAuthenticatedDevice({ id, error });
   }
 }
 

--- a/src/interactors/ListDevices.js
+++ b/src/interactors/ListDevices.js
@@ -8,7 +8,7 @@ class ListDevices {
 
   async execute() {
     const devices = await this.cloudConnector.listDevices();
-    await this.queue.send('fog', 'device.list', devices.map((dev) => {
+    await this.queue.sendList(devices.map((dev) => {
       const device = dev;
       device.schema = convertToSnakeCase(dev.schema);
       return device;

--- a/src/interactors/ListDevices.js
+++ b/src/interactors/ListDevices.js
@@ -1,18 +1,25 @@
 import convertToSnakeCase from '../util/snakeCase';
 
 class ListDevices {
-  constructor(cloudConnector, queue) {
+  constructor(cloudConnector, publisher) {
     this.cloudConnector = cloudConnector;
-    this.queue = queue;
+    this.publisher = publisher;
   }
 
   async execute() {
-    const devices = await this.cloudConnector.listDevices();
-    await this.queue.sendList(devices.map((dev) => {
-      const device = dev;
-      device.schema = convertToSnakeCase(dev.schema);
-      return device;
-    }));
+    try {
+      const devices = await this.cloudConnector.listDevices();
+      await this.publisher.sendList({
+        devices: devices.map((dev) => {
+          const device = dev;
+          device.schema = convertToSnakeCase(dev.schema);
+          return device;
+        }),
+        error: null,
+      });
+    } catch (error) {
+      await this.publisher.sendList({ devices: [], error: error.message });
+    }
   }
 }
 

--- a/src/interactors/RegisterDevice.js
+++ b/src/interactors/RegisterDevice.js
@@ -16,7 +16,7 @@ class RegisterDevice {
 
     await this.deviceStore.add(deviceToBeSaved);
     const registeredDevice = await this.cloudConnector.addDevice(deviceToBeSaved);
-    await this.queue.send('fog', 'device.registered', registeredDevice);
+    await this.queue.sendRegisteredDevice(registeredDevice);
   }
 }
 

--- a/src/interactors/RegisterDevice.js
+++ b/src/interactors/RegisterDevice.js
@@ -14,8 +14,8 @@ class RegisterDevice {
       name,
     };
 
-    await this.deviceStore.add(deviceToBeSaved);
     const registeredDevice = await this.cloudConnector.addDevice(deviceToBeSaved);
+    await this.deviceStore.add(deviceToBeSaved);
     await this.queue.sendRegisteredDevice(registeredDevice);
   }
 }

--- a/src/interactors/RegisterDevice.js
+++ b/src/interactors/RegisterDevice.js
@@ -1,10 +1,10 @@
 import logger from 'util/logger';
 
 class RegisterDevice {
-  constructor(deviceStore, cloudConnector, queue) {
+  constructor(deviceStore, cloudConnector, publisher) {
     this.deviceStore = deviceStore;
     this.cloudConnector = cloudConnector;
-    this.queue = queue;
+    this.publisher = publisher;
   }
 
   async execute({ id, name }) {
@@ -13,10 +13,18 @@ class RegisterDevice {
       id,
       name,
     };
+    let msgResponse;
 
-    const registeredDevice = await this.cloudConnector.addDevice(deviceToBeSaved);
-    await this.deviceStore.add(deviceToBeSaved);
-    await this.queue.sendRegisteredDevice(registeredDevice);
+    try {
+      msgResponse = await this.cloudConnector.addDevice(deviceToBeSaved);
+      msgResponse.error = null;
+      await this.deviceStore.add(deviceToBeSaved);
+    } catch (error) {
+      logger.error(error.message);
+      msgResponse = { id, token: '', error: error.message };
+    }
+
+    await this.publisher.sendRegisteredDevice(msgResponse);
   }
 }
 

--- a/src/interactors/UnregisterDevice.js
+++ b/src/interactors/UnregisterDevice.js
@@ -8,8 +8,8 @@ class UnregisterDevice {
 
   async execute(device) {
     logger.debug(`Device ${device.id} removed`);
-    await this.deviceStore.remove(device);
     await this.cloudConnector.removeDevice(device.id);
+    await this.deviceStore.remove(device);
   }
 }
 

--- a/src/interactors/UnregisterDevice.js
+++ b/src/interactors/UnregisterDevice.js
@@ -1,15 +1,21 @@
 import logger from 'util/logger';
 
 class UnregisterDevice {
-  constructor(deviceStore, cloudConnector) {
+  constructor(deviceStore, cloudConnector, publisher) {
     this.deviceStore = deviceStore;
     this.cloudConnector = cloudConnector;
+    this.publisher = publisher;
   }
 
   async execute(device) {
     logger.debug(`Device ${device.id} removed`);
-    await this.cloudConnector.removeDevice(device.id);
-    await this.deviceStore.remove(device);
+    try {
+      await this.cloudConnector.removeDevice(device.id);
+      await this.deviceStore.remove(device);
+    } catch (err) {
+      logger.error(err.stack);
+      await this.publisher.sendUnregisteredDevice({ id: device.id, error: err.message });
+    }
   }
 }
 

--- a/src/interactors/UpdateSchema.js
+++ b/src/interactors/UpdateSchema.js
@@ -2,20 +2,20 @@ import logger from 'util/logger';
 import convertToCamelCase from 'util/camelCase';
 
 class UpdateSchema {
-  constructor(deviceStore, cloudConnector, queue) {
+  constructor(deviceStore, cloudConnector, publisher) {
     this.deviceStore = deviceStore;
     this.cloudConnector = cloudConnector;
-    this.queue = queue;
+    this.publisher = publisher;
   }
 
   async execute(device) {
     try {
       await this.cloudConnector.updateSchema(device.id, convertToCamelCase(device.schema));
       await this.deviceStore.update(device.id, { schema: convertToCamelCase(device.schema) });
-      this.queue.send('fog', 'schema.updated', { id: device.id, error: null });
+      this.publisher.sendSchemaUpdated({ id: device.id, error: null });
       logger.debug(`Device ${device.id} schema updated`);
     } catch (error) {
-      this.queue.send('fog', 'schema.updated', { id: device.id, error: error.message });
+      this.publisher.sendSchemaUpdated({ id: device.id, error: error.message });
     }
   }
 }

--- a/src/network/AMQPConnection.js
+++ b/src/network/AMQPConnection.js
@@ -26,11 +26,11 @@ class AMQPConnection {
     );
   }
 
-  async onMessage(topic, key, callback) {
+  async onMessage(topic, key, callback, noAck) {
     await this.channel.assertExchange(topic, 'topic', { durable: true });
     const { queue } = await this.channel.assertQueue(`${topic}-messages`, { durable: true });
     await this.channel.bindQueue(queue, topic, key);
-    return this.channel.consume(queue, callback);
+    return this.channel.consume(queue, callback, { noAck });
   }
 
   async cancelConsume(consumerTag) {

--- a/src/network/AMQPConnection.js
+++ b/src/network/AMQPConnection.js
@@ -16,13 +16,13 @@ class AMQPConnection {
     });
   }
 
-  async send(topic, key, message) {
+  async send(topic, key, message, expiration) {
     await this.channel.assertExchange(topic, 'topic', { durable: true });
     await this.channel.publish(
       topic,
       key,
       Buffer.from(JSON.stringify(message)),
-      { persistent: true },
+      { persistent: true, expiration },
     );
   }
 

--- a/src/network/CloudConnectionHandler.js
+++ b/src/network/CloudConnectionHandler.js
@@ -30,7 +30,7 @@ class CloudConnectionHandler {
 
   async onDeviceUnregistered(id) {
     logger.debug(`Device ${id} unregistered`);
-    await this.queue.sendUnregisteredDevice({ id });
+    await this.queue.sendUnregisteredDevice({ id, error: null });
   }
 
   async onDisconnected() {

--- a/src/network/CloudConnectionHandler.js
+++ b/src/network/CloudConnectionHandler.js
@@ -20,27 +20,27 @@ class CloudConnectionHandler {
       logger.debug(`Update data from ${sensorId} of thing ${id}: ${value}`);
     });
 
-    await this.queue.send('fog', 'data.update', { id, data: convertToSnakeCase(data) });
+    await this.queue.sendDataUpdate({ id, data: convertToSnakeCase(data) });
   }
 
   async onDataRequested(id, sensorIds) {
     logger.debug(`Data requested from ${sensorIds} of thing ${id}`);
-    await this.queue.send('fog', 'data.request', { id, data: sensorIds });
+    await this.queue.sendDataRequest({ id, data: sensorIds });
   }
 
   async onDeviceUnregistered(id) {
     logger.debug(`Device ${id} unregistered`);
-    await this.queue.send('fog', 'device.unregistered', { id });
+    await this.queue.sendUnregisteredDevice({ id });
   }
 
   async onDisconnected() {
     logger.debug('Cloud disconnected');
-    await this.queue.send('control', 'disconnected', {});
+    await this.queue.sendDisconnected();
   }
 
   async onReconnected() {
     logger.debug('Cloud reconnected');
-    await this.queue.send('control', 'reconnected', {});
+    await this.queue.sendReconnected();
   }
 }
 

--- a/src/network/MessageHandler.js
+++ b/src/network/MessageHandler.js
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 import logger from 'util/logger';
 
+const exchangeConnectorIn = 'connIn';
+
 class MessageHandler {
   constructor(devicesService, dataService, queue) {
     this.devicesService = devicesService;
@@ -11,7 +13,7 @@ class MessageHandler {
 
   mapMessageHandlers() {
     return {
-      cloud: {
+      [exchangeConnectorIn]: {
         'device.register': {
           method: this.devicesService.register.bind(this.devicesService),
         },
@@ -54,13 +56,13 @@ class MessageHandler {
   }
 
   async handleDisconnected() {
-    _.keys(this.handlers.cloud).forEach(async (key) => {
-      await this.queue.cancelConsume(this.handlers.cloud[key].consumerTag);
+    _.keys(this.handlers[exchangeConnectorIn]).forEach(async (key) => {
+      await this.queue.cancelConsume(this.handlers[exchangeConnectorIn][key].consumerTag);
     });
   }
 
   async handleReconnected() {
-    await this.listenToQueueMessages('cloud');
+    await this.listenToQueueMessages(exchangeConnectorIn);
   }
 
   async handleMessage(msg) {

--- a/src/network/MessageHandlerFactory.js
+++ b/src/network/MessageHandlerFactory.js
@@ -26,7 +26,7 @@ class MessageHandlerFactory {
 
     const loadDevices = new LoadDevices(deviceStore, cloud);
     const registerDevice = new RegisterDevice(deviceStore, cloud, publisher);
-    const unregisterDevice = new UnregisterDevice(deviceStore, cloud);
+    const unregisterDevice = new UnregisterDevice(deviceStore, cloud, publisher);
     const authDevice = new AuthDevice(cloud, publisher);
     const updateSchema = new UpdateSchema(deviceStore, cloud, publisher);
     const listDevices = new ListDevices(cloud, publisher);

--- a/src/network/MessageHandlerFactory.js
+++ b/src/network/MessageHandlerFactory.js
@@ -12,23 +12,24 @@ import PublishData from 'interactors/PublishData';
 import DataService from 'services/DataService';
 
 class MessageHandlerFactory {
-  constructor(deviceStore, cloud, amqpConnection) {
+  constructor(deviceStore, cloud, amqpConnection, publisher) {
     this.deviceStore = deviceStore;
     this.cloud = cloud;
     this.amqpConnection = amqpConnection;
+    this.publisher = publisher;
   }
 
   create() {
     const {
-      deviceStore, cloud, amqpConnection,
+      deviceStore, cloud, amqpConnection, publisher,
     } = this;
 
     const loadDevices = new LoadDevices(deviceStore, cloud);
-    const registerDevice = new RegisterDevice(deviceStore, cloud, amqpConnection);
+    const registerDevice = new RegisterDevice(deviceStore, cloud, publisher);
     const unregisterDevice = new UnregisterDevice(deviceStore, cloud);
-    const authDevice = new AuthDevice(cloud, amqpConnection);
-    const updateSchema = new UpdateSchema(deviceStore, cloud, amqpConnection);
-    const listDevices = new ListDevices(cloud, amqpConnection);
+    const authDevice = new AuthDevice(cloud, publisher);
+    const updateSchema = new UpdateSchema(deviceStore, cloud, publisher);
+    const listDevices = new ListDevices(cloud, publisher);
     const devicesService = new DevicesService(
       loadDevices,
       registerDevice,

--- a/src/network/MessagePublisher.js
+++ b/src/network/MessagePublisher.js
@@ -1,0 +1,46 @@
+const exchangeName = 'fog';
+const exchangeControl = 'control';
+
+class MessagePublisher {
+  constructor(queue) {
+    this.queue = queue;
+  }
+
+  async sendRegisteredDevice(body) {
+    await this.queue.send(exchangeName, 'device.registered', body);
+  }
+
+  async sendAuthenticatedDevice(body) {
+    await this.queue.send(exchangeName, 'device.auth', body);
+  }
+
+  async sendSchemaUpdated(body) {
+    await this.queue.send(exchangeName, 'schema.updated', body);
+  }
+
+  async sendList(body) {
+    await this.queue.send(exchangeName, 'device.list', body);
+  }
+
+  async sendDataUpdate(body) {
+    await this.queue.send(exchangeName, 'data.update', body);
+  }
+
+  async sendDataRequest(body) {
+    await this.queue.send(exchangeName, 'data.request', body);
+  }
+
+  async sendUnregisteredDevice(body) {
+    await this.queue.send(exchangeName, 'device.unregistered', body);
+  }
+
+  async sendDisconnected() {
+    await this.queue.send(exchangeControl, 'disconnected', {});
+  }
+
+  async sendReconnected() {
+    await this.queue.send(exchangeControl, 'reconnected', {});
+  }
+}
+
+export default MessagePublisher;

--- a/src/network/MessagePublisher.js
+++ b/src/network/MessagePublisher.js
@@ -1,4 +1,4 @@
-const exchangeName = 'fog';
+const exchangeName = 'connOut';
 const exchangeControl = 'control';
 
 class MessagePublisher {

--- a/src/network/MessagePublisher.js
+++ b/src/network/MessagePublisher.js
@@ -1,5 +1,6 @@
 const exchangeName = 'connOut';
 const exchangeControl = 'control';
+const expirationTime = 10000;
 
 class MessagePublisher {
   constructor(queue) {
@@ -23,11 +24,11 @@ class MessagePublisher {
   }
 
   async sendDataUpdate(body) {
-    await this.queue.send(exchangeName, 'data.update', body);
+    await this.queue.send(exchangeName, 'data.update', body, expirationTime);
   }
 
   async sendDataRequest(body) {
-    await this.queue.send(exchangeName, 'data.request', body);
+    await this.queue.send(exchangeName, 'data.request', body, expirationTime);
   }
 
   async sendUnregisteredDevice(body) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patchset changes the API to avoid that a message is re-queued when there is some error on connector library. Now the client that sent the message receives the message with the error to handle it.

Does this close any currently open issues?
------------------------------------------
Fixes #36, Fixes #27, Fixes #35 

Any relevant logs, error output, etc?
-------------------------------------
No

Where has this been tested?
---------------------------

**Operating System/Platform:** 4.15.0-70-generic #79-Ubuntu SMP Tue Nov 12 10:36:11 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

**NPM Version:** 6.7.0

**NodeJS Version:** 11.13

