### PR TITLE
rabbitmq: Add support to username and password

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -20,7 +20,9 @@
 	},
 	"rabbitMQ": {
 		"hostname": "RABBITMQ_HOSTNAME",
-		"port": "RABBITMQ_PORT"
+		"port": "RABBITMQ_PORT",
+		"username": "RABBITMQ_USERNAME",
+		"password": "RABBITMQ_PASSWORD"
 	},
 	"cloudType": "CLOUD_TYPE",
 	"cloud": {

--- a/config/default.json
+++ b/config/default.json
@@ -11,6 +11,8 @@
 	},
 	"rabbitMQ": {
 		"hostname": "localhost",
-		"port": 5672
+		"port": 5672,
+		"username": "guest",
+		"password": "guest"
 	}
 }

--- a/src/data/SettingsFactory.js
+++ b/src/data/SettingsFactory.js
@@ -17,6 +17,8 @@ const runAsSchema = Joi.object().keys({
 const rabbitMQSchema = Joi.object().keys({
   hostname: Joi.string().required(),
   port: Joi.number().port().required(),
+  username: Joi.string().required(),
+  password: Joi.string().required(),
 });
 
 class SettingsFactory {

--- a/src/network/AMQPConnection.js
+++ b/src/network/AMQPConnection.js
@@ -2,7 +2,7 @@ import amqplib from 'amqp-connection-manager';
 
 class AMQPConnection {
   constructor(settings) {
-    this.url = `amqp://${settings.hostname}:${settings.port}`;
+    this.url = `amqp://${settings.username}:${settings.password}@${settings.hostname}:${settings.port}`;
   }
 
   async start(setupFunction) {


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
The RabbitMQ server doesn't allow connecting to it with the guest user
when the client is running outside the localhost network. Therefore,
this patch enables connector to receive user and password properties via
configuration and use them to create the appropriate connection URL.