### PR TITLE
Fix DataRequest operation message key

### DIFF
--- a/src/network/CloudConnectionHandler.js
+++ b/src/network/CloudConnectionHandler.js
@@ -25,7 +25,7 @@ class CloudConnectionHandler {
 
   async onDataRequested(id, sensorIds) {
     logger.debug(`Data requested from ${sensorIds} of thing ${id}`);
-    await this.queue.sendDataRequest({ id, data: sensorIds });
+    await this.queue.sendDataRequest({ id, sensorIds });
   }
 
   async onDeviceUnregistered(id) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch fix the key of data.request operation message. This is necessary because others services expect a different key name.

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.4
**NPM Version:** 6.14.4
**NodeJS Version:** 12.15
