### PR TITLE
amqp: Fix storing leftover data events

### DIFF
--- a/src/network/AMQPConnection.js
+++ b/src/network/AMQPConnection.js
@@ -35,7 +35,7 @@ class AMQPConnection {
       durable: true,
     });
     const { queue } = await this.channel.assertQueue(
-      'connector-event-messages',
+      `connector-event-${exchangeName}`,
       { durable: true }
     );
     await this.channel.bindQueue(queue, exchangeName, key);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch creates a queue for every defined exchange in order to avoid
binding consumers that disable auto acknowledgment to a single queue that
also receives events that can't be retained and wait for an explicit
ack.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS Darwin 18.0.0

**NPM Version:** v12.16.2

**NodeJS Version:** 6.14.4