### PR TITLE
Fix AMQP reconnection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,14 +28,13 @@ async function main() {
     }
 
     const amqpConnection = new AMQPConnectionFactory(settings.fog).create();
-    const amqpChannel = await amqpConnection.start();
+    await amqpConnection.start();
 
     const publisher = new MessagePublisher(amqpConnection, settings.fog.token);
     const cloudConnectionHandler = new CloudConnectionHandler(cloud, publisher);
     const messageHandler = new MessageHandlerFactory(
       cloud,
-      amqpConnection,
-      amqpChannel
+      amqpConnection
     ).create();
 
     await cloudConnectionHandler.start();

--- a/src/network/AMQPConnection.js
+++ b/src/network/AMQPConnection.js
@@ -1,4 +1,5 @@
 import amqplib from 'amqp-connection-manager';
+import logger from 'util/logger';
 
 class AMQPConnection {
   constructor(settings) {
@@ -12,11 +13,17 @@ class AMQPConnection {
       connection.createChannel({
         json: true,
         setup: (channel) => {
+          logger.debug(
+            'Connection established with RabbitMQ. New channel created.'
+          );
           this.channel = channel;
           this.subscribeListeners();
           resolve(channel);
         },
       });
+      connection.on('disconnect', () =>
+        logger.debug('Disconnected from RabbitMQ, trying to reconnect.')
+      );
     });
   }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Always when the connection with the message broker is re-established a new channel object is generated. In this context, considering the message handler receives a channel like that to do some operations and the instance of it is created with a channel generated before reconnection, the operations end up failing.

The solution is to respect the separability between layers and avoid to call a channel object direct in the message handler. So, this patch moves some of the operations to the AMQP component in a way the channel is now properly under control.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** ...

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2