### PR TITLE
Add update config (fog <-> cloud)

### DIFF
--- a/__mocks__/@cesarbr/knot-fog-connector-knot-cloud.js
+++ b/__mocks__/@cesarbr/knot-fog-connector-knot-cloud.js
@@ -1,6 +1,7 @@
 export const mockAddDevice = jest.fn();
 export const mockRemoveDevice = jest.fn();
 export const mockUpdateSchema = jest.fn();
+export const mockUpdateConfig = jest.fn();
 export const mockPublishData = jest.fn();
 
 export default jest.fn().mockImplementation((options = {}) => {
@@ -22,6 +23,12 @@ export default jest.fn().mockImplementation((options = {}) => {
     mockUpdateSchema.mockResolvedValue();
   }
 
+  if (options.updateConfigErr) {
+    mockUpdateConfig.mockRejectedValue(Error(options.updateConfigErr));
+  } else {
+    mockUpdateConfig.mockResolvedValue();
+  }
+
   if (options.publishDataErr) {
     mockPublishData.mockRejectedValue(Error(options.publishDataErr));
   } else {
@@ -32,6 +39,7 @@ export default jest.fn().mockImplementation((options = {}) => {
     addDevice: mockAddDevice,
     removeDevice: mockRemoveDevice,
     updateSchema: mockUpdateSchema,
+    updateConfig: mockUpdateConfig,
     publishData: mockPublishData,
   };
 });

--- a/src/interactors/UpdateConfig.js
+++ b/src/interactors/UpdateConfig.js
@@ -1,0 +1,22 @@
+import logger from 'util/logger';
+import equal from 'deep-equal';
+
+class UpdateConfig {
+  constructor(cloudConnector) {
+    this.cloudConnector = cloudConnector;
+  }
+
+  async execute(updatedDevice) {
+    try {
+      await this.cloudConnector.updateConfig(
+        updatedDevice.id,
+        updatedDevice.config
+      );
+      logger.debug(`Device ${updatedDevice.id} config updated`);
+    } catch (err) {
+      logger.error(err.message);
+    }
+  }
+}
+
+export default UpdateConfig;

--- a/src/interactors/interactors.test.js
+++ b/src/interactors/interactors.test.js
@@ -2,6 +2,7 @@ import Cloud, * as cloudMocks from '@cesarbr/knot-fog-connector-knot-cloud';
 import RegisterDevice from './RegisterDevice';
 import UnregisterDevice from './UnregisterDevice';
 import UpdateSchema from './UpdateSchema';
+import UpdateConfig from './UpdateConfig';
 import PublishData from './PublishData';
 
 jest.mock('@cesarbr/knot-fog-connector-knot-cloud');
@@ -18,6 +19,15 @@ const mockThing = {
       name: 'bool-sensor',
     },
   ],
+  config: [
+    {
+      sensorId: 0,
+      change: true,
+      timeSec: 10,
+      lowerThreshold: 1000,
+      upperThreshold: 3000,
+    },
+  ],
 };
 const mockData = [
   {
@@ -31,6 +41,7 @@ describe('Interactors', () => {
     cloudMocks.mockAddDevice.mockClear();
     cloudMocks.mockRemoveDevice.mockClear();
     cloudMocks.mockUpdateSchema.mockClear();
+    cloudMocks.mockUpdateConfig.mockClear();
     cloudMocks.mockPublishData.mockClear();
   });
 
@@ -76,6 +87,22 @@ describe('Interactors', () => {
     const updateSchema = new UpdateSchema(cloud);
     await updateSchema.execute(mockThing);
     expect(cloudMocks.mockUpdateSchema).toHaveBeenCalled();
+  });
+
+  test("should execute correctly when updating a thing's config on cloud", async () => {
+    const cloud = new Cloud();
+    const updateConfig = new UpdateConfig(cloud);
+    await updateConfig.execute(mockThing);
+    expect(cloudMocks.mockUpdateConfig).toHaveBeenCalled();
+  });
+
+  test("should execute without errors when updating a thing's config on cloud fails", async () => {
+    const cloud = new Cloud({
+      updateConfigErr: "fail to update thing's config",
+    });
+    const updateConfig = new UpdateConfig(cloud);
+    await updateConfig.execute(mockThing);
+    expect(cloudMocks.mockUpdateConfig).toHaveBeenCalled();
   });
 
   test("should execute correctly when publishing a thing's data to the cloud", async () => {

--- a/src/network/CloudConnectionHandler.js
+++ b/src/network/CloudConnectionHandler.js
@@ -9,6 +9,7 @@ class CloudConnectionHandler {
   async start() {
     this.cloud.onDataUpdated(this.onDataUpdated.bind(this));
     this.cloud.onDataRequested(this.onDataRequested.bind(this));
+    this.cloud.onConfigUpdated(this.onConfigUpdated.bind(this));
     this.cloud.onDisconnected(this.onDisconnected.bind(this));
     this.cloud.onReconnected(this.onReconnected.bind(this));
   }
@@ -24,6 +25,11 @@ class CloudConnectionHandler {
   async onDataRequested(id, sensorIds) {
     logger.debug(`Data requested from ${sensorIds} of thing ${id}`);
     await this.queue.sendDataRequest({ id, sensorIds });
+  }
+
+  async onConfigUpdated(id, config) {
+    logger.debug(`Received config update command to thing ${id}`);
+    await this.queue.sendUpdateConfig({ id, config });
   }
 
   async onDisconnected() {

--- a/src/network/MessageHandler.js
+++ b/src/network/MessageHandler.js
@@ -54,6 +54,15 @@ class MessageHandler {
           noAck: true,
           exchangeType: 'direct',
         },
+        'device.config.updated': {
+          method: ({ error, ...message }) => {
+            if (!error) {
+              this.devicesService.updateConfig(message);
+            }
+          },
+          noAck: true,
+          exchangeType: 'direct',
+        },
       },
       [publishDataExchange]: {
         '': {

--- a/src/network/MessageHandlerFactory.js
+++ b/src/network/MessageHandlerFactory.js
@@ -3,6 +3,7 @@ import MessageHandler from 'network/MessageHandler';
 import RegisterDevice from 'interactors/RegisterDevice';
 import UnregisterDevice from 'interactors/UnregisterDevice';
 import UpdateSchema from 'interactors/UpdateSchema';
+import UpdateConfig from 'interactors/UpdateConfig';
 import DevicesService from 'services/DevicesService';
 
 import PublishData from 'interactors/PublishData';
@@ -21,10 +22,12 @@ class MessageHandlerFactory {
     const registerDevice = new RegisterDevice(cloud);
     const unregisterDevice = new UnregisterDevice(cloud);
     const updateSchema = new UpdateSchema(cloud);
+    const updateConfig = new UpdateConfig(cloud);
     const devicesService = new DevicesService(
       registerDevice,
       unregisterDevice,
-      updateSchema
+      updateSchema,
+      updateConfig
     );
 
     const publishData = new PublishData(cloud);

--- a/src/network/MessagePublisher.js
+++ b/src/network/MessagePublisher.js
@@ -30,6 +30,17 @@ class MessagePublisher {
     );
   }
 
+  async sendUpdateConfig(body) {
+    await this.queue.send(
+      deviceExchange,
+      'direct',
+      'device.config.sent',
+      body,
+      { Authorization: this.token },
+      expirationTime
+    );
+  }
+
   async sendDisconnected() {
     await this.queue.send(
       exchangeControl,

--- a/src/services/DevicesService.js
+++ b/src/services/DevicesService.js
@@ -2,11 +2,13 @@ class DevicesService {
   constructor(
     registerDeviceInteractor,
     unregisterDeviceInteractor,
-    updateSchemaInteractor
+    updateSchemaInteractor,
+    updateConfigInteractor
   ) {
     this.registerDeviceInteractor = registerDeviceInteractor;
     this.unregisterDeviceInteractor = unregisterDeviceInteractor;
     this.updateSchemaInteractor = updateSchemaInteractor;
+    this.updateConfigInteractor = updateConfigInteractor;
   }
 
   async register(device) {
@@ -19,6 +21,10 @@ class DevicesService {
 
   async updateSchema(device) {
     await this.updateSchemaInteractor.execute(device);
+  }
+
+  async updateConfig(device) {
+    await this.updateConfigInteractor.execute(device);
   }
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch includes the following changes:

- Add handler for processing update config commands that are received from the cloud;
- Add update config interactor to send an update config request to the cloud;
- Add a `DeviceStore` component to store the current device representations and avoid looping through messages from the KNoT Fog/KNoT Cloud.
- Update unit tests.

Does this close any currently open issues?
------------------------------------------
Nops.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS Darwin - 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2

(Add more information here if needed.)
